### PR TITLE
fix compile dependencies bug

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -68,6 +68,8 @@ git clone --recursive https://github.com/unitreerobotics/z1_ros.git
 cd ..
 
 rosdep install --from-paths src --ignore-src -yr --rosdistro noetic
+# compile unitree_legged_msgs first
+catkin_make --pkg unitree_legged_msgs
 catkin_make
 source devel/setup.bash
 ```


### PR DESCRIPTION
# Resolve Dependency Issue by Prioritizing the Compilation of 'unitree_legged_msgs' Package

## Description

**Overview:**

This pull request addresses a dependency issue encountered while compiling the 'z1_ros' package. Specifically, the 'z1_controller' package relies on the 'unitree_legged_msgs' package, which is currently an uncompiled dependency. To resolve this issue, I propose prioritizing the compilation of the 'unitree_legged_msgs' package to ensure smooth compilation of the 'z1_ros' package.

**Background:**

The 'z1_ros' package comprises several independent packages with complex interdependencies. As a result, when attempting to compile 'z1_ros', the uncompiled 'unitree_legged_msgs' package causes a build failure due to missing dependencies.

**Proposed Solution:**

To mitigate the dependency issue, I suggest compiling the 'unitree_legged_msgs' package first before attempting to build the 'z1_ros' package. By doing so, I ensure that all necessary dependencies are satisfied, and 'z1_controller' can access the required messages and services from 'unitree_legged_msgs'.

**Steps to Resolve:**

1. Compile 'unitree_legged_msgs' package:
   - Confirm that 'unitree_legged_msgs' is added to the catkin workspace under 'src'.
   - Execute `catkin_make --pkg unitree_legged_msgs` to compile the package.

2. Compile 'z1_ros' package:
   - After successfully compiling 'unitree_legged_msgs', proceed to build 'z1_ros'.
   - Execute `catkin_make --pkg z1_ros` to build 'z1_ros' along with its dependencies.

**Environment:**
Ubuntu20.04 VMWARE
ROS1 Noetic

**Testing:**

To verify the successful resolution of the dependency issue, I have tested the proposed solution on a ROS environment with dependencies identical to 'z1_ros'. The build process now completes without errors, confirming that 'unitree_legged_msgs' is successfully compiled and utilized as a dependency.


**Additional Notes:**

If accepted, this pull request will ensure a smoother compilation process for the 'z1_ros' package, avoiding potential dependency conflicts and enabling users to utilize the 'z1_controller' package seamlessly.

Thank you for considering this pull request.

